### PR TITLE
Fix compatibility issues due to ModsConfig.IsActive

### DIFF
--- a/1.4/Source/ModCompatibility.cs
+++ b/1.4/Source/ModCompatibility.cs
@@ -6,7 +6,7 @@ namespace VREArchon
 {
     public static class ModCompatibility
     {
-        public static bool VPELoaded = ModsConfig.IsActive("VanillaExpanded.VPsycastsE");
+        public static bool VPELoaded = ModsConfig.IsActive("VanillaExpanded.VPsycastsE") || ModsConfig.IsActive("VanillaExpanded.VPsycastsE_steam");
 
         public static AbilityDef RandomPsycastDef()
         {


### PR DESCRIPTION
The issue occurs when checking if a mod is active with `ModsConfig.IsActive` when running the workshop version of a mod while there's a local copy in the mods directory. In those cases the `ModsConfig.IsActive` will return false as the running mod will have the `_steam` postfix.

The simple fix is to simply check for mod ID, as well as the mod ID with the `_steam` postfix.

For related PRs, check:
Vanilla-Expanded/VanillaExpandedFramework#72